### PR TITLE
[Scaling] Request to change fontSize to font.pixelSize 

### DIFF
--- a/maliit-keyboard/qml/Keyboard.qml
+++ b/maliit-keyboard/qml/Keyboard.qml
@@ -195,7 +195,7 @@ Item {
             z: 1001
 
             // TODO: Make title font part of styling profile.
-            font.pointSize: 48
+            font.pixelSize: Theme.fontSizeMedium
             color: "white"
         }
     }

--- a/nemo-keyboard/nemo-keyboard.qml
+++ b/nemo-keyboard/nemo-keyboard.qml
@@ -46,12 +46,6 @@ Item {
             return
 
         var x = 0, y = 0, width = 0, height = 0;
-
-        /*var pos = keyboard.mapToItem(canvas, 0, -keyboard.height);
-        y = pos.y;
-        x = pos.x;
-        width = keyboard.width;
-        height = keyboard.height;*/
         var angle = MInputMethodQuick.appOrientation
 
         switch (angle) {
@@ -85,7 +79,6 @@ Item {
 
         width: landscape ? parent.height : parent.width
         height: 1
-       // y: parent.height
         transformOrigin: Item.TopLeft
         onRotationChanged: updateIMArea()
         rotation: MInputMethodQuick.appOrientation

--- a/nemo-keyboard/org/nemomobile/CharacterKey.qml
+++ b/nemo-keyboard/org/nemomobile/CharacterKey.qml
@@ -42,7 +42,7 @@ KeyBase  {
     property string symView
     property string symView2
     property string sizeType: "keyboard-key-43x60.png"
-    property int fontSize: Theme.fontSizeLarge
+    property int fontSize: Theme.fontSizeMedium
     property alias text: key_label.text
     property string imagesrc: bgImage.source
 
@@ -65,7 +65,7 @@ KeyBase  {
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
         font.family: "sans"
-        font.pointSize: fontSize
+        font.pixelSize: fontSize
         font.bold: true
         color:Theme.textColor// UI.TEXT_COLOR
         text: (inSymView && symView.length) > 0 ? (inSymView2 ? symView2 : symView)

--- a/nemo-keyboard/org/nemomobile/FunctionKey.qml
+++ b/nemo-keyboard/org/nemomobile/FunctionKey.qml
@@ -81,7 +81,7 @@ KeyBase {
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
         font.family: "sans"
-        font.pointSize: Theme.fontSizeMedium
+        font.pixelSize: Theme.fontSizeSmall
         //font.bold: true
         color: Theme.textColor//UI.TEXT_COLOR
         text: caption

--- a/nemo-keyboard/org/nemomobile/KeyBase.qml
+++ b/nemo-keyboard/org/nemomobile/KeyBase.qml
@@ -38,7 +38,7 @@ Item {
     property int topPadding
     property int bottomPadding
     property bool landscape
-    property int fontSize: UI.FONT_SIZE
+    property int fontSize: Theme.fontSizeSmall
     property bool pressed
     property bool repeat
     property string text

--- a/nemo-keyboard/org/nemomobile/Popper.qml
+++ b/nemo-keyboard/org/nemomobile/Popper.qml
@@ -48,7 +48,7 @@ import QtQuick.Controls.Styles.Nemo 1.0
         anchors.centerIn: parent
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
-        font.pointSize: Theme.fontSizeExtraLarge
+        font.pixelSize: Theme.fontSizeLarge
         font.family: "sans"
         //font.pixelSize: parent.height/3
         font.bold: true


### PR DESCRIPTION
Now the Theme.fontSizes are really small if scalable pixelSize is used, request to change that.
We should use pixelSize since pointSize is not really reliable on scaling.
Depends on nemomobile/qtquickcontrols-nemo#49